### PR TITLE
Development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+nginx/tls/*

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,9 @@
+
+
+Copyright 2025 zvdy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # TCP File Streaming Service
 
+[![Go Report Card](https://goreportcard.com/badge/github.com/zvdy/tcp-file-streaming)](https://goreportcard.com/report/github.com/zvdy/tcp-file-streaming)
+
 This project is a TCP file streaming service designed to handle file transfers over a network. It includes several components that work together to provide a robust and scalable solution for streaming files.
 
 ## Components

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Consul is used for service discovery and health checks. It helps manage the serv
 
 ### Running the Service
 
+> Alternatively you can generate a crt and key in order to use https, bear in mind that curl would need the -k flag in order to work.
+
 1. **Check the health of the Golang HTTP Service**:
 
     ```sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
       dockerfile: Dockerfile
     ports:
       - "80:80"
+      - "443:443"
     depends_on:
       - consul
       - server

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -13,8 +13,13 @@ RUN apt-get update && \
 # Copy Nginx configuration
 COPY nginx.conf /etc/nginx/nginx.conf
 
-# Expose port 80
+# Copy the self-signed certificate and key
+COPY tls/nginx.crt /etc/nginx/ssl/nginx.crt
+COPY tls/nginx.key /etc/nginx/ssl/nginx.key
+
+# Expose ports 80 and 443
 EXPOSE 80
+EXPOSE 443
 
 # Command to run Consul and Nginx
 CMD ["sh", "-c", "consul agent -dev -client=0.0.0.0 -join=consul & \

--- a/nginx/generate_cert.sh
+++ b/nginx/generate_cert.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Define the directory to store the certificate and key
+CERT_DIR="./nginx/tls"
+mkdir -p $CERT_DIR
+
+# Generate a self-signed certificate and key
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout $CERT_DIR/nginx.key -out $CERT_DIR/nginx.crt -subj "/C=US/ST=State/L=City/O=Organization/OU=Department/CN=localhost"
+
+echo "Self-signed certificate and key generated at $CERT_DIR"

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -9,6 +9,10 @@ http {
 
     server {
         listen 80;
+        listen 443 ssl;
+
+        ssl_certificate /etc/nginx/ssl/nginx.crt;
+        ssl_certificate_key /etc/nginx/ssl/nginx.key;
 
         location / {
             proxy_pass http://backend;


### PR DESCRIPTION
This pull request includes several changes to add HTTPS support to the TCP File Streaming Service, update the documentation, and include a license file. The most important changes are grouped by theme below:

### HTTPS Support:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R37): Added port 443 to the exposed ports for the service.
* [`nginx/Dockerfile`](diffhunk://#diff-9ec03da71dcf2a84bfcdbb2cbe709b5f15d7304432ba66ed4a6912fc661912faL16-R22): Added commands to copy the self-signed certificate and key, and exposed port 443.
* [`nginx/generate_cert.sh`](diffhunk://#diff-21a3cfb4c70ad12b8dabb43d8fcc072fe47b78f42af0bfb4b34f673bc3da9babR1-R10): Created a script to generate a self-signed certificate and key.
* [`nginx/nginx.conf`](diffhunk://#diff-4adaaefa7fc959e7dfe65e8dc8dadc9ee27ddd284eee3426463b1cdc000587d5R12-R15): Configured Nginx to listen on port 443 with SSL enabled and specified the paths for the certificate and key.

### Documentation Updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R3-R4): Added a Go Report Card badge and instructions for generating a certificate and using HTTPS with the `-k` flag in curl. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R3-R4) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R62-R63)

### License Addition:

* [`LICENSE`](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7R1-R9): Added a new license file to the project.